### PR TITLE
chore: bump emp-wasm version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "emp-wasm": "^0.1.3",
+        "emp-wasm": "^0.1.7",
         "mpc-framework-common": "^0.1.0",
         "msgpackr": "^1.11.0",
         "sha3": "^2.1.4"
@@ -884,9 +884,9 @@
       }
     },
     "node_modules/emp-wasm": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/emp-wasm/-/emp-wasm-0.1.3.tgz",
-      "integrity": "sha512-si/alEkEkX51ZwmGem6PScrTA8YOg82axjCEOGhqWg0K9XHuDmFy8hYOfFA7Y0pWbukN69oFKqx4PKKG7X0Rvw==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/emp-wasm/-/emp-wasm-0.1.7.tgz",
+      "integrity": "sha512-GaivW3JA8Pxe1DxtD7ZSBhso93cqBFRIApppkkkM/qI55mueEYwXhE3hRn9I/yjmJkbnYYlto5plGJ8mEYHDRw==",
       "dependencies": {
         "ee-typed": "^0.1.0",
         "events": "^3.3.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "emp-wasm": "^0.1.3",
+    "emp-wasm": "^0.1.7",
     "mpc-framework-common": "^0.1.0",
     "msgpackr": "^1.11.0",
     "sha3": "^2.1.4"


### PR DESCRIPTION
`emp-wasm`, on which `emp-wasm-backend` depends, has recently been patched. This PR updates its version.

Tests pass.