### PR TITLE
chore: update package type to "module"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "emp-wasm-backend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "emp-wasm-backend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "emp-wasm": "^0.1.7",
-        "mpc-framework-common": "^0.1.0",
+        "mpc-framework-common": "^0.1.1",
         "msgpackr": "^1.11.0",
         "sha3": "^2.1.4"
       },
@@ -19,12 +19,34 @@
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.12.11",
         "chai": "^5.1.1",
-        "ee-typed": "^0.1.0",
+        "ee-typed": "^0.1.1",
         "mocha": "^10.4.0",
-        "mpc-framework": "^0.1.1",
-        "summon-ts": "^0.2.1",
+        "mpc-framework": "^0.1.2",
+        "summon-ts": "^0.2.5",
         "tsx": "^4.9.3",
         "typescript": "^5.4.5"
+      }
+    },
+    "../emp-wasm": {
+      "version": "0.1.7",
+      "license": "MIT",
+      "dependencies": {
+        "ee-typed": "^0.1.1",
+        "events": "^3.3.0"
+      },
+      "devDependencies": {
+        "@types/chai": "^5.0.0",
+        "@types/mocha": "^10.0.9",
+        "@types/node": "^22.7.5",
+        "@types/ws": "^8.5.12",
+        "chai": "^5.1.1",
+        "concurrently": "^9.0.1",
+        "mocha": "^10.7.3",
+        "peerjs": "^1.5.4",
+        "tsx": "^4.19.1",
+        "typescript": "^5.6.3",
+        "vite": "^5.4.8",
+        "ws": "^8.18.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -499,6 +521,7 @@
       "version": "20.16.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.5.tgz",
       "integrity": "sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -875,22 +898,18 @@
       }
     },
     "node_modules/ee-typed": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ee-typed/-/ee-typed-0.1.0.tgz",
-      "integrity": "sha512-tLlZ5IrB0KGJYTtqawcyY5Bl7T3ssUyq1huccSrj1X8qlSdStu0D+ShzMZaZOQubxnPXFMhjcB2+RKJqeYu00Q==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ee-typed/-/ee-typed-0.1.1.tgz",
+      "integrity": "sha512-atfgRdyoqK/QOY7dqv4jwAi7th45DDX2zRjGgLR8zRgJy7QSLyoS6aI1jZbKf/VIrXy9YTpHFCr8Mzxj//a/KA==",
+      "dev": true,
       "dependencies": {
         "@types/node": "^20.14.2",
         "typed-emitter": "^2.1.0"
       }
     },
     "node_modules/emp-wasm": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/emp-wasm/-/emp-wasm-0.1.7.tgz",
-      "integrity": "sha512-GaivW3JA8Pxe1DxtD7ZSBhso93cqBFRIApppkkkM/qI55mueEYwXhE3hRn9I/yjmJkbnYYlto5plGJ8mEYHDRw==",
-      "dependencies": {
-        "ee-typed": "^0.1.0",
-        "events": "^3.3.0"
-      }
+      "resolved": "../emp-wasm",
+      "link": true
     },
     "node_modules/esbuild": {
       "version": "0.23.1",
@@ -950,14 +969,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "engines": {
-        "node": ">=0.8.x"
       }
     },
     "node_modules/fill-range": {
@@ -1305,9 +1316,9 @@
       }
     },
     "node_modules/mpc-framework": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/mpc-framework/-/mpc-framework-0.1.1.tgz",
-      "integrity": "sha512-z8QhkEq9/db77Lj7rqkklnhDDF2Ff/XocT6qPx+KJmJsfe03ftuBWJpZzhdii85FrH1oAlsmNdWS/sF2geRLlQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/mpc-framework/-/mpc-framework-0.1.2.tgz",
+      "integrity": "sha512-E0zQoMN3YyVfIC/IMEhVzJU17JDZE6PfmkCMzX4etkoAhpnntlUnyaJ+03eDtKi1WKF2FYLMQhWWAVi47Ku4IA==",
       "dev": true,
       "dependencies": {
         "ee-typed": "^0.1.0",
@@ -1317,14 +1328,9 @@
       }
     },
     "node_modules/mpc-framework-common": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/mpc-framework-common/-/mpc-framework-common-0.1.0.tgz",
-      "integrity": "sha512-JeE7gKoqAC/9ZlGclHs/DCACi7KHfJZRZoQWU1GnO7hzHjPakJgZTfZFYXuvmEprP3olvMas7AQp3uVuixsI8Q==",
-      "dependencies": {
-        "ee-typed": "^0.1.0",
-        "msgpackr": "^1.11.0",
-        "zod": "^3.23.8"
-      }
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/mpc-framework-common/-/mpc-framework-common-0.1.1.tgz",
+      "integrity": "sha512-D+o1vSdFPl9v55c0kgM2dGcUR0IZQn3teeQHA5pWiwjokbMt7uiNHHqQKyrzsY2Y4TfBbVKjnS9yjM6szIO5Ng=="
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1496,6 +1502,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -1551,9 +1558,9 @@
       }
     },
     "node_modules/summon-ts": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/summon-ts/-/summon-ts-0.2.1.tgz",
-      "integrity": "sha512-Xc+584n4+sa1h1qO3FJP4YXvBukMmTAAm2z51ysXoVLdlseH7f2Ua02o15xSnw5bOTLV5dErbNOZUcExQOPMFQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/summon-ts/-/summon-ts-0.2.5.tgz",
+      "integrity": "sha512-VtsdFLyvctiYzgfXFH18UlD5u9Do8aNU0sBxiiDT0Tqdru1vAT+LfBwLSRfisry5avEUheYWMFL/5Hix3rIo5Q==",
       "dev": true
     },
     "node_modules/supports-color": {
@@ -1587,6 +1594,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true,
       "optional": true
     },
     "node_modules/tsx": {
@@ -1612,6 +1620,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
       "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "dev": true,
       "optionalDependencies": {
         "rxjs": "*"
       }
@@ -1632,7 +1641,8 @@
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "node_modules/workerpool": {
       "version": "6.5.1",
@@ -1754,6 +1764,7 @@
       "version": "3.23.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
       "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "emp-wasm-backend",
   "version": "0.2.0",
   "description": "Backend for mpc-framework powered by emp-toolkit/emp-ag2pc",
+  "type": "module",
   "main": "dist/src/index.js",
   "scripts": {
     "build": "rm -rf dist && tsc",
@@ -26,16 +27,16 @@
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.12.11",
     "chai": "^5.1.1",
-    "ee-typed": "^0.1.0",
+    "ee-typed": "^0.1.1",
     "mocha": "^10.4.0",
-    "mpc-framework": "^0.1.1",
-    "summon-ts": "^0.2.1",
+    "mpc-framework": "^0.1.2",
+    "summon-ts": "^0.2.5",
     "tsx": "^4.9.3",
     "typescript": "^5.4.5"
   },
   "dependencies": {
     "emp-wasm": "^0.1.7",
-    "mpc-framework-common": "^0.1.0",
+    "mpc-framework-common": "^0.1.1",
     "msgpackr": "^1.11.0",
     "sha3": "^2.1.4"
   }

--- a/src/EmpCircuit.ts
+++ b/src/EmpCircuit.ts
@@ -1,7 +1,7 @@
 import { Circuit, MpcSettings } from "mpc-framework-common";
-import parseBristol, { Bristol } from "./parseBristol";
-import assert from "./assert";
-import never from "./never";
+import parseBristol, { Bristol } from "./parseBristol.js";
+import assert from "./assert.js";
+import never from "./never.js";
 
 type EmpGate = (
   | { type: 'AND'; left: number; right: number; output: number }

--- a/src/EmpWasmBackend.ts
+++ b/src/EmpWasmBackend.ts
@@ -5,7 +5,7 @@ import {
   Circuit,
   MpcSettings,
 } from "mpc-framework-common";
-import EmpWasmSession from "./EmpWasmSession";
+import EmpWasmSession from "./EmpWasmSession.js";
 
 export default class EmpWasmBackend implements Backend {
   run(

--- a/src/EmpWasmSession.ts
+++ b/src/EmpWasmSession.ts
@@ -2,11 +2,11 @@ import { Keccak } from "sha3";
 import { BackendSession, Circuit, MpcSettings } from "mpc-framework-common";
 import { BufferQueue, secure2PC } from "emp-wasm";
 
-import defer from "./defer";
+import defer from "./defer.js";
 import { pack } from "msgpackr";
-import buffersEqual from "./buffersEqual";
+import buffersEqual from "./buffersEqual.js";
 import { Buffer } from 'buffer';
-import EmpCircuit from "./EmpCircuit";
+import EmpCircuit from "./EmpCircuit.js";
 
 export default class EmpWasmSession implements BackendSession {
   peerName: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { default as EmpWasmBackend } from "./EmpWasmBackend";
+export { default as EmpWasmBackend } from "./EmpWasmBackend.js";


### PR DESCRIPTION
## What is this PR doing?

This PR resolves compatibility issues with Node.js by setting the package type to module in package.json. This ensures the package works in both modern browsers and Node.js environments.

Related: https://github.com/voltrevo/summon-ts/pull/1

This PR depends on https://github.com/voltrevo/emp-wasm/pull/2. Before merging, the `emp-wasm` dependency needs to be updated.

## How can these changes be manually tested?

It can be tested locally by trying to use this package from NodeJS.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat
