### PR TITLE
fix: sort circuit and mpc-settings objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "emp-wasm": "^0.1.8",
         "mpc-framework-common": "^0.1.1",
         "msgpackr": "^1.11.0",
-        "sha3": "^2.1.4"
+        "sha3": "^2.1.4",
+        "sort-keys": "^5.1.0"
       },
       "devDependencies": {
         "@types/chai": "^4.3.20",
@@ -1695,6 +1696,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
@@ -2241,6 +2253,20 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/sort-keys": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-5.1.0.tgz",
+      "integrity": "sha512-aSbHV0DaBcr7u0PVHXzM6NbZNAtrr9sF6+Qfs9UUVG7Ll3jQ6hHi8F/xqIIcn2rvIVbr0v/2zyjSdwSV47AgLQ==",
+      "dependencies": {
+        "is-plain-obj": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "emp-wasm": "^0.1.8",
     "mpc-framework-common": "^0.1.1",
     "msgpackr": "^1.11.0",
-    "sha3": "^2.1.4"
+    "sha3": "^2.1.4",
+    "sort-keys": "^5.1.0"
   }
 }

--- a/src/EmpWasmSession.ts
+++ b/src/EmpWasmSession.ts
@@ -1,4 +1,5 @@
 import { Keccak } from "sha3";
+
 import { BackendSession, Circuit, MpcSettings } from "mpc-framework-common";
 import { BufferQueue, secure2PC } from "emp-wasm";
 
@@ -6,6 +7,7 @@ import defer from "./defer.js";
 import buffersEqual from "./buffersEqual.js";
 import EmpCircuit from "./EmpCircuit.js";
 import packBuffer from "./packBuffer.js";
+import sortKeys from 'sort-keys';
 
 export default class EmpWasmSession implements BackendSession {
   peerName: string;
@@ -37,7 +39,7 @@ export default class EmpWasmSession implements BackendSession {
 
   async run() {
     const setupHash = Uint8Array.from(new Keccak(256).update(
-      packBuffer([this.circuit, this.mpcSettings])
+      packBuffer([sortKeys(this.circuit, { deep: true }), sortKeys(this.mpcSettings, { deep: true })])
     ).digest());
 
     this.send(this.peerName, setupHash);


### PR DESCRIPTION
## What is this PR doing?

This PR adds a package ([sort-keys](https://www.npmjs.com/package/sort-keys)) to sort the `circuit` and `mpcSettings` objects so that all parties share the same objects (thus hashes) even if the original order is different. 

This bug was found in the [client-server MPC-Hello](https://github.com/voltrevo/mpc-hello/tree/main/client-server) demo. The app only works the first time it's run. In particular, when the client is refreshed and the server is not restarted, the server compiles the circuit and generates a different output compared to the client.

What's different is the `info.input_name_to_wire_index` field of the circuit output:

- `{ a: 0, b: 16 }` the first time
- `{ b: 16, a: 0 }` the second time

The cause of the problem is the `HashMap` (like https://github.com/voltrevo/boolify/pull/2), which does not maintain any particular order, as its internal structure is based on hashing.

Although this PR solves the problem in this library, it is then necessary to use another data structure, such as `BTreeMap`, to preserve the order of the keys.

## How can these changes be manually tested?

Build the package on this branch and use it as a local dependency with the [client-server MPC-Hello](https://github.com/voltrevo/mpc-hello/tree/main/client-server) demo. It will work correctly even after the first computation.

## Does this PR resolve or contribute to any issues?

No.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
