### PR TITLE
N party upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "emp-wasm-backend",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "emp-wasm-backend",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
-        "emp-wasm": "^0.1.8",
+        "emp-wasm": "^0.2.0",
         "mpc-framework-common": "^0.1.1",
         "msgpackr": "^1.11.0",
         "sha3": "^2.1.4",
@@ -1347,9 +1347,9 @@
       "license": "MIT"
     },
     "node_modules/emp-wasm": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/emp-wasm/-/emp-wasm-0.1.8.tgz",
-      "integrity": "sha512-qjWXF1ewt3N+h3xxT50z8iSMjutis+BGLs55ZA0cPY6SAGIzofyOfpDrxdYAn7iq0ExUZqkxqO553D6e/+ny5g==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/emp-wasm/-/emp-wasm-0.2.0.tgz",
+      "integrity": "sha512-t4Suz2ocDb+hm4tjuDLWeJwrwSEaKnUI9spWZ+442LO38guBsHNslEt3cVRJnEQg5i35syMDbk9dsFUHhM5xtA==",
       "license": "MIT",
       "dependencies": {
         "ee-typed": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "vite": "^6.0.7"
   },
   "dependencies": {
-    "emp-wasm": "^0.1.8",
+    "emp-wasm": "^0.2.0",
     "mpc-framework-common": "^0.1.1",
     "msgpackr": "^1.11.0",
     "sha3": "^2.1.4",

--- a/src/EmpCircuit.ts
+++ b/src/EmpCircuit.ts
@@ -12,6 +12,7 @@ type EmpGate = (
 export default class EmpCircuit {
   private bristol: Bristol;
   private info: Circuit['info'];
+  public originalCircuit: Circuit;
 
   private metadata: {
     wireCount: number;
@@ -21,7 +22,7 @@ export default class EmpCircuit {
   };
   private gates: EmpGate[] = [];
 
-  private partyNames: string[] = [];
+  public partyNames: string[] = [];
   private partyInputs: Record<string, string[]> = {};
   private allInputs: string[];
   private outputs: string[];
@@ -41,6 +42,7 @@ export default class EmpCircuit {
   ) {
     this.bristol = parseBristol(circuit.bristol);
     this.info = circuit.info;
+    this.originalCircuit = circuit;
 
     const partyNamesSet = new Set<string>();
 
@@ -307,6 +309,24 @@ export default class EmpCircuit {
     assert(outputIndex !== -1, `Output ${outputName} not found`);
 
     return this.bristol.outputWidths[outputIndex];
+  }
+
+  hasPartyName(name: string): boolean {
+    return this.partyNames.includes(name);
+  }
+
+  partyNameFromIndex(index: number): string {
+    const partyName = this.partyNames[index];
+    assert(partyName !== undefined, `Party index ${index} not found`);
+
+    return partyName;
+  }
+
+  partyIndexFromName(name: string): number {
+    const index = this.partyNames.indexOf(name);
+    assert(index !== -1, `Party name ${name} not found`);
+
+    return index;
   }
 
   getInputBitsPerParty(): number[] {

--- a/src/EmpCircuit.ts
+++ b/src/EmpCircuit.ts
@@ -11,7 +11,6 @@ type EmpGate = (
 
 export default class EmpCircuit {
   private bristol: Bristol;
-  private info: Circuit['info'];
   public originalCircuit: Circuit;
 
   private metadata: {
@@ -41,7 +40,6 @@ export default class EmpCircuit {
     mpcSettings: MpcSettings,
   ) {
     this.bristol = parseBristol(circuit.bristol);
-    this.info = circuit.info;
     this.originalCircuit = circuit;
 
     const partyNamesSet = new Set<string>();
@@ -94,7 +92,7 @@ export default class EmpCircuit {
 
     for (const inputName of allInputsInPartyOrder) {
       const width = this.getInputWidth(inputName);
-      const oldWireId = this.info.input_name_to_wire_index[inputName];
+      const oldWireId = this.originalCircuit.info.input_name_to_wire_index[inputName];
       assert(oldWireId !== undefined, `Input ${inputName} not found`);
 
       for (let i = 0; i < width; i++) {
@@ -103,7 +101,7 @@ export default class EmpCircuit {
       }
     }
 
-    const oldFirstOutputWireId = this.info.output_name_to_wire_index[this.outputs[0]];
+    const oldFirstOutputWireId = this.originalCircuit.info.output_name_to_wire_index[this.outputs[0]];
 
     for (const g of this.bristol.gates) {
       let outputWireId: number;
@@ -392,7 +390,7 @@ export default class EmpCircuit {
 
     for (const outputName of this.outputs) {
       const width = this.getOutputWidth(outputName);
-      const oldWireId = this.info.output_name_to_wire_index[outputName];
+      const oldWireId = this.originalCircuit.info.output_name_to_wire_index[outputName];
 
       let value = 0;
 

--- a/src/EmpWasmBackend.ts
+++ b/src/EmpWasmBackend.ts
@@ -6,6 +6,7 @@ import {
   MpcSettings,
 } from "mpc-framework-common";
 import EmpWasmSession from "./EmpWasmSession.js";
+import EmpCircuit from "./EmpCircuit.js";
 
 export default class EmpWasmBackend implements Backend {
   run(
@@ -24,19 +25,14 @@ export default class EmpWasmBackend implements Backend {
       throw checkResult;
     }
 
-    const aliceName = mpcSettings[0].name ?? "0";
-    const bobName = mpcSettings[1].name ?? "1";
-
-    if (name !== aliceName && name !== bobName) {
-      throw new Error(`Unknown participant name: ${name}`);
-    }
+    const empCircuit = new EmpCircuit(circuit, mpcSettings);
 
     return new EmpWasmSession(
-      circuit,
+      empCircuit,
       mpcSettings,
       input,
       send,
-      name === aliceName,
+      name,
     );
   }
 }
@@ -45,10 +41,6 @@ export function checkSettingsValidForEmpWasm(
   circuit: Circuit,
   mpcSettings: MpcSettings,
 ): Error | undefined {
-  if (mpcSettings.length !== 2) {
-    return new Error("EmpWasmBackend requires exactly two participants");
-  }
-
   for (const participant of mpcSettings) {
     if (!checkStringSetsEqual(
       participant.outputs,

--- a/src/EmpWasmSession.ts
+++ b/src/EmpWasmSession.ts
@@ -1,7 +1,7 @@
 import { Keccak } from "sha3";
 
-import { BackendSession, Circuit, MpcSettings } from "mpc-framework-common";
-import { BufferQueue, secure2PC } from "emp-wasm";
+import { BackendSession, MpcSettings } from "mpc-framework-common";
+import { BufferQueue, secureMPC } from "emp-wasm";
 
 import defer from "./defer.js";
 import buffersEqual from "./buffersEqual.js";
@@ -10,62 +10,109 @@ import packBuffer from "./packBuffer.js";
 import sortKeys from 'sort-keys';
 
 export default class EmpWasmSession implements BackendSession {
-  peerName: string;
-  bq = new BufferQueue();
+  bqs = new BufferQueueStore();
   result = defer<Record<string, unknown>>();
 
   constructor(
-    public circuit: Circuit,
+    public empCircuit: EmpCircuit,
     public mpcSettings: MpcSettings,
     public input: Record<string, unknown>,
-    public send: (to: string, msg: Uint8Array) => void,
-    public isAlice: boolean,
+    public rawSend: (to: string, msg: Uint8Array) => void,
+    public thisPartyName: string,
   ) {
-    this.peerName = mpcSettings[isAlice ? 1 : 0].name ?? (isAlice ? "1" : "0");
-
     this.run().catch(err => {
       this.result.reject(err);
     });
   }
 
   handleMessage(from: string, msg: Uint8Array): void {
-    if (from !== this.peerName) {
-      console.error("Received message from unknown peer", from);
-      return;
+    if (!this.empCircuit.hasPartyName(from)) {
+      throw new Error(`Received message from unknown peer: ${from}`);
     }
 
-    this.bq.push(msg);
+    const channel = channelFromByte(msg[0]);
+    this.bqs.get(from, channel).push(msg.slice(1));
+  }
+
+  send(to: string, channel: 'a' | 'b', msg: Uint8Array): void {
+    const fullMsg = new Uint8Array(msg.length + 1);
+    fullMsg[0] = channel.charCodeAt(0);
+    fullMsg.set(msg, 1);
+
+    this.rawSend(to, fullMsg);
   }
 
   async run() {
     const setupHash = Uint8Array.from(new Keccak(256).update(
-      packBuffer([sortKeys(this.circuit, { deep: true }), sortKeys(this.mpcSettings, { deep: true })])
+      packBuffer([
+        sortKeys(this.empCircuit.originalCircuit, { deep: true }),
+        sortKeys(this.mpcSettings, { deep: true }),
+      ])
     ).digest());
 
-    this.send(this.peerName, setupHash);
-
-    const msg = await this.bq.pop(32);
-
-    if (!buffersEqual(msg, setupHash)) {
-      throw new Error("Setup hash mismatch: check peer settings match");
+    for (const partyName of this.empCircuit.partyNames) {
+      if (partyName !== this.thisPartyName) {
+        this.send(partyName, 'a', setupHash);
+      }
     }
 
-    const empCircuit = new EmpCircuit(this.circuit, this.mpcSettings);
+    // This needs to be in a separate loop so that we send all our hashes before
+    // we start waiting on the responses.
+    for (const partyName of this.empCircuit.partyNames) {
+      if (partyName !== this.thisPartyName) {
+        const setupHashReceived = await this.bqs
+          .get(partyName, 'a')
+          .pop(setupHash.length);
 
-    const outputBits = await secure2PC(
-      this.isAlice ? 'alice' : 'bob',
-      empCircuit.getSimplifiedBristol(),
-      empCircuit.encodeInput(this.isAlice ? 'alice' : 'bob', this.input),
-      {
-        send: data => this.send(this.peerName, data),
-        recv: len => this.bq.pop(len),
+        if (!buffersEqual(setupHash, setupHashReceived)) {
+          throw new Error(`Setup hash mismatch with ${partyName}`);
+        }
+      }
+    }
+
+    const outputBits = await secureMPC({
+      party: this.empCircuit.partyIndexFromName(this.thisPartyName),
+      size: this.empCircuit.partyNames.length,
+      circuit: this.empCircuit.getSimplifiedBristol(),
+      inputBits: this.empCircuit.encodeInput(this.thisPartyName, this.input),
+      inputBitsPerParty: this.empCircuit.getInputBitsPerParty(),
+      io: {
+        send: (toParty, channel, data) =>
+          this.send(this.empCircuit.partyNameFromIndex(toParty), channel, data),
+        recv: (fromParty, channel, len) =>
+          this.bqs.get(this.empCircuit.partyNameFromIndex(fromParty), channel).pop(len),
       },
-    );
+    });
 
-    this.result.resolve(empCircuit.decodeOutput(outputBits));
+    this.result.resolve(this.empCircuit.decodeOutput(outputBits));
   }
 
   output(): Promise<Record<string, unknown>> {
     return this.result.promise;
+  }
+}
+
+class BufferQueueStore {
+  bqs = new Map<string, BufferQueue>();
+
+  get(from: string, channel: 'a' | 'b') {
+    const key = `${from}-${channel}`;
+
+    if (!this.bqs.has(key)) {
+      this.bqs.set(key, new BufferQueue());
+    }
+
+    return this.bqs.get(key)!;
+  }
+}
+
+function channelFromByte(byte: number): 'a' | 'b' {
+  switch (byte) {
+    case 'a'.charCodeAt(0):
+      return 'a';
+    case 'b'.charCodeAt(0):
+      return 'b';
+    default:
+      throw new Error('Invalid channel');
   }
 }

--- a/tests/EmpCircuit.test.ts
+++ b/tests/EmpCircuit.test.ts
@@ -65,20 +65,22 @@ test('correctly evals circuit', async () => {
     circuit,
     [
       {
+        name: 'alice',
         inputs: ['a'],
         outputs: ['main'],
       },
       {
+        name: 'bob',
         inputs: ['b'],
         outputs: ['main'],
       },
     ],
   );
 
-  const outputs = ec.eval(
-    { a: 3 },
-    { b: 5 },
-  );
+  const outputs = ec.eval({
+    alice: { a: 3 },
+    bob: { b: 5 },
+  });
 
   expect(outputs).to.deep.equal({ main: 15 });
 });

--- a/tests/helpers/AsyncQueueStore.ts
+++ b/tests/helpers/AsyncQueueStore.ts
@@ -1,0 +1,18 @@
+import AsyncQueue from "./AsyncQueue";
+
+export default class AsyncQueueStore<T> {
+  queues = new Map<string, AsyncQueue<T>>();
+
+  get(from: string, to: string) {
+    const key = JSON.stringify([from, to]);
+
+    let queue = this.queues.get(key);
+
+    if (queue === undefined) {
+      queue = new AsyncQueue<T>();
+      this.queues.set(key, queue);
+    }
+
+    return queue;
+  }
+}

--- a/tests/mpc.test.ts
+++ b/tests/mpc.test.ts
@@ -116,8 +116,11 @@ test("middle(8, 17, 5) == 8", async () => {
   ]);
 });
 
-// FIXME: this test skipped
+// FIXME: this test is skipped
 // FIXME: use 5 bidders and auction house (which doesn't bid but observes)
+// NOTE:  this circuit also failed with consensus on the same bad outputs before
+//        the N parties upgrade, so there's something else going on:
+//        https://github.com/voltrevo/emp-wasm-backend/commit/be67477
 testOpt("vickrey(8, 17, 5) == [1, 8]", { skip: true }, async () => {
   await summon.init();
 

--- a/tests/mpc.test.ts
+++ b/tests/mpc.test.ts
@@ -3,12 +3,10 @@ import { expect } from 'chai';
 import { Protocol } from 'mpc-framework';
 import * as summon from 'summon-ts';
 
-
 import { EmpWasmBackend } from '../src';
-import assert from '../src/assert';
 
-import AsyncQueue from './helpers/AsyncQueue';
 import { test } from './helpers/suite';
+import AsyncQueueStore from './helpers/AsyncQueueStore';
 
 test("max(3, 5) === 5", async () => {
   await summon.init();
@@ -40,38 +38,113 @@ test("max(3, 5) === 5", async () => {
     new EmpWasmBackend(),
   );
 
-  const aliceQueue = new AsyncQueue<Uint8Array>();
-  const bobQueue = new AsyncQueue<Uint8Array>();
+  const aqs = new AsyncQueueStore<Uint8Array>();
 
   const outputs = await Promise.all([
-    runSide(protocol, 'alice', { a: 3 }, aliceQueue, bobQueue),
-    runSide(protocol, 'bob', { b: 5 }, aliceQueue, bobQueue),
+    runParty(protocol, 'alice', { a: 3 }, aqs),
+    runParty(protocol, 'bob', { b: 5 }, aqs),
   ]);
 
   expect(outputs).to.deep.equal([{ main: 5 }, { main: 5 }]);
 });
 
-async function runSide(
-  protocol: Protocol,
-  side: 'alice' | 'bob',
-  input: Record<string, number>,
-  aliceQueue: AsyncQueue<Uint8Array>,
-  bobQueue: AsyncQueue<Uint8Array>,
-) {
-  const otherSide = side === 'alice' ? 'bob' : 'alice';
-  const myQueue = side === 'alice' ? aliceQueue : bobQueue;
-  const otherQueue = side === 'alice' ? bobQueue : aliceQueue;
+test("vickrey(8, 17, 5) == [1, 8]", async () => {
+  await summon.init();
 
+  const circuit = summon.compileBoolean('/src/main.ts', 16, {
+    '/src/main.ts': `
+      export default function main(
+        a: number,
+        b: number,
+        c: number,
+      ) {
+        const nums = [a, b, c];
+
+        const winner = 0;
+        const highest = a;
+        const secondHighest = 0;
+
+        for (let i = 1; i < nums.length; i++) {
+          if (nums[i] > highest) {
+            secondHighest = highest;
+            highest = nums[i];
+            winner = i;
+          } else if (nums[i] > secondHighest) {
+            secondHighest = nums[i];
+          }
+        }
+
+        return [winner, secondHighest];
+      }
+    `,
+  });
+
+  const mpcSettings = [
+    {
+      name: 'alice',
+      inputs: ['a'],
+      outputs: ['main[0]', 'main[1]'],
+    },
+    {
+      name: 'bob',
+      inputs: ['b'],
+      outputs: ['main[0]', 'main[1]'],
+    },
+    {
+      name: 'charlie',
+      inputs: ['c'],
+      outputs: ['main[0]', 'main[1]'],
+    },
+  ];
+
+  const protocol = new Protocol(
+    circuit,
+    mpcSettings,
+    new EmpWasmBackend(),
+  );
+
+  const aqs = new AsyncQueueStore<Uint8Array>();
+
+  const outputs = await Promise.all([
+    runParty(protocol, 'alice', { a: 8 }, aqs),
+    runParty(protocol, 'bob', { b: 17 }, aqs),
+    runParty(protocol, 'charlie', { c: 5 }, aqs),
+  ]);
+
+  expect(outputs).to.deep.equal([
+    // Participant index 1 (Bob) wins the auction with the highest bid, but only
+    // pays the second highest bid. His actual bid is kept secret.
+    { 'main[0]': 1, 'main[1]': 8 },
+    { 'main[0]': 1, 'main[1]': 8 },
+    { 'main[0]': 1, 'main[1]': 8 },
+  ]);
+});
+
+async function runParty(
+  protocol: Protocol,
+  party: string,
+  input: Record<string, number>,
+  aqs: AsyncQueueStore<Uint8Array>,
+) {
   const session = protocol.join(
-    side,
+    party,
     input,
     (to, msg) => {
-      assert(to === otherSide);
-      otherQueue.push(msg);
+      aqs.get(party, to).push(msg);
     },
   );
 
-  myQueue.stream(data => session.handleMessage(otherSide, data));
+  const partyNames = protocol.mpcSettings.map(
+    ({ name }, i) => name ?? `party${i}`,
+  );
+
+  for (const otherParty of partyNames) {
+    if (otherParty !== party) {
+      aqs.get(otherParty, party).stream(
+        data => session.handleMessage(otherParty, data),
+      );
+    }
+  }
 
   const output = await session.output();
 


### PR DESCRIPTION
## What is this PR doing?

- Upgrades to N parties!
  - (Like, for realz this time. After we release this secure N-party MPC will actually be available to MPC Framework users.)
- Uses the updated emp-wasm dependency
- Updates the surrounding adapter to work with N parties instead of Alice and Bob
- New tests, including a failing test, but that was found to fail before these changes also, so it will be addressed separately
  - [Task to fix the test](https://www.notion.so/pse-team/Fix-Vickrey-Auction-test-192d57e8dd7e80fab531e897fe87ba00?pvs=4)
- Adds test skipping functionality

## How can these changes be manually tested?

`npm test`

## Does this PR resolve or contribute to any issues?

https://www.notion.so/pse-team/Update-emp-wasm-backend-for-N-parties-190d57e8dd7e809c9654ea10e1d11ec2?pvs=4

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
