### PR TITLE
Fix vickrey auction

### DIFF
--- a/src/EmpCircuit.ts
+++ b/src/EmpCircuit.ts
@@ -250,11 +250,13 @@ export default class EmpCircuit {
       inputBits1 = 0;
     }
 
+    const wireCount = this.nextWireId;
+
     this.metadata = {
-      wireCount: this.nextWireId,
+      wireCount,
       inputBits0,
       inputBits1,
-      outputBits: sum(this.outputs.map((n) => this.getOutputWidth(n))),
+      outputBits: wireCount - this.firstOutputWireId,
     };
   }
 

--- a/tests/helpers/suite.ts
+++ b/tests/helpers/suite.ts
@@ -10,20 +10,25 @@ let suite: TestDefinition[] = [];
 let failures = 0;
 let autorun = true;
 
-export async function testOpt(
-  name: string,
-  options: TestDefinition['options'],
-  fn: () => unknown,
+export async function test(
+  ...args:
+    | [name: string, fn: () => unknown]
+    | [name: string, options: TestDefinition['options'], fn: () => unknown]
 ) {
+  let name, options, fn;
+
+  if (args.length === 2) {
+    [name, fn] = args;
+    options = {};
+  } else {
+    [name, options, fn] = args;
+  }
+
   suite.push({ name, options, fn });
 
   if (autorun) {
     queueMicrotask(runSuite);
   }
-}
-
-export async function test(name: string, fn: () => unknown) {
-  return testOpt(name, {}, fn);
 }
 
 export function setSuiteAutorun(value: boolean) {

--- a/tests/helpers/suite.ts
+++ b/tests/helpers/suite.ts
@@ -2,6 +2,7 @@ type TestDefinition = {
   name: string,
   options: {
     skip?: boolean,
+    only?: boolean,
   },
   fn: () => unknown,
 };
@@ -43,12 +44,14 @@ export async function runSuite() {
   const capturedSuite = suite;
   suite = [];
 
+  const hasOnly = capturedSuite.some(({ options }) => options.only);
+
   console.log(`Running ${capturedSuite.length} tests...`);
 
   const puppeteerDetected = (globalThis as any).reportToPuppeteer !== undefined;
 
   for (const { name, options, fn } of capturedSuite) {
-    if (options.skip) {
+    if (options.skip || (hasOnly && !options.only)) {
       console.log(`🟡 SKIPPED: ${name}`);
       continue;
     }

--- a/tests/mpc.test.ts
+++ b/tests/mpc.test.ts
@@ -116,11 +116,7 @@ test("middle(8, 17, 5) == 8", async () => {
   ]);
 });
 
-// FIXME: this test is skipped
 // FIXME: use 5 bidders and auction house (which doesn't bid but observes)
-// NOTE:  this circuit also failed with consensus on the same bad outputs before
-//        the N parties upgrade, so there's something else going on:
-//        https://github.com/voltrevo/emp-wasm-backend/commit/be67477
 test("vickrey(8, 17, 5) == [1, 8]", async () => {
   await summon.init();
 

--- a/tests/mpc.test.ts
+++ b/tests/mpc.test.ts
@@ -121,7 +121,7 @@ test("middle(8, 17, 5) == 8", async () => {
 // NOTE:  this circuit also failed with consensus on the same bad outputs before
 //        the N parties upgrade, so there's something else going on:
 //        https://github.com/voltrevo/emp-wasm-backend/commit/be67477
-test("vickrey(8, 17, 5) == [1, 8]", { skip: true }, async () => {
+test("vickrey(8, 17, 5) == [1, 8]", async () => {
   await summon.init();
 
   const circuit = summon.compileBoolean('/src/main.ts', 8, {

--- a/tests/mpc.test.ts
+++ b/tests/mpc.test.ts
@@ -5,7 +5,7 @@ import * as summon from 'summon-ts';
 
 import { EmpWasmBackend } from '../src';
 
-import { test, testOpt } from './helpers/suite';
+import { test } from './helpers/suite';
 import AsyncQueueStore from './helpers/AsyncQueueStore';
 
 test("max(3, 5) === 5", async () => {
@@ -121,7 +121,7 @@ test("middle(8, 17, 5) == 8", async () => {
 // NOTE:  this circuit also failed with consensus on the same bad outputs before
 //        the N parties upgrade, so there's something else going on:
 //        https://github.com/voltrevo/emp-wasm-backend/commit/be67477
-testOpt("vickrey(8, 17, 5) == [1, 8]", { skip: true }, async () => {
+test("vickrey(8, 17, 5) == [1, 8]", { skip: true }, async () => {
   await summon.init();
 
   const circuit = summon.compileBoolean('/src/main.ts', 8, {


### PR DESCRIPTION
## What is this PR doing?

Fixes the calculation of `outputBits` which caused corrupted output decoding (and outputting some internal circuit bits!) when the circuit re-uses actual bits multiple times when generating outputs, which most often happens with constant zero and one bits. This is common when you return numbers in a small range, because if you use eg 8 bits then most of the high bits will be zero constants.

Also:
- Allow specifying options as an overload of `test`, replacing `testOpt`
- Add `only` option (use `only: true` to only run that test)

## How can these changes be manually tested?

`npm test`

## Does this PR resolve or contribute to any issues?

Resolves https://www.notion.so/pse-team/Fix-Vickrey-Auction-test-192d57e8dd7e80fab531e897fe87ba00?pvs=4.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
