### PR TITLE
Add bool encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "emp-wasm-engine",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "emp-wasm-engine",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emp-wasm-engine",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Engine for mpc-framework powered by emp-toolkit",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## What is this PR doing?

Adds boolean encoding. This means you can (and now must) provide inputs that are declared with `summon.bool()` as booleans, and outputs that were booleans in summon are received as booleans instead of 0 and 1.

## How can these changes be manually tested?

Check the new `boolean io` test and run `npm test`.

## Does this PR resolve or contribute to any issues?

Contributes to https://www.notion.so/pse-team/Rich-IO-15ed57e8dd7e80058612d5519bff625b?pvs=4

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
