### PR TITLE
Use updated emp wasm, summon-ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "emp-wasm-engine",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "emp-wasm-engine",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "glob": "^11.0.1",
         "mpc-framework": "^0.3.0",
         "puppeteer-core": "^24.1.0",
-        "summon-ts": "^0.6.0",
+        "summon-ts": "^0.6.1",
         "tsx": "^4.9.3",
         "typescript": "^5.4.5",
         "vite": "^6.0.7"
@@ -2444,9 +2444,9 @@
       }
     },
     "node_modules/summon-ts": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/summon-ts/-/summon-ts-0.6.0.tgz",
-      "integrity": "sha512-mY0Z5gHovzT9Htscj+gBswiLr9ADSMpQplqybuEPvsdCde85Uz2dpCDG8ucffl/6xpVzDEG/JoXbH+SXKzjCqg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/summon-ts/-/summon-ts-0.6.1.tgz",
+      "integrity": "sha512-6CzWD6KfbnRWKk+5qw4iTyRl6Vh+dVT0/ZpvHGHYXgABHR9HKmW7DaS3RIY/o1rVKLH8dXczuukljZUMVHVbdg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@msgpack/msgpack": "^3.1.1",
         "@noble/hashes": "^1.7.1",
-        "emp-wasm": "^0.2.2",
+        "emp-wasm": "^0.3.2",
         "mpc-framework-common": "^0.3.0",
         "sort-keys": "^5.1.0"
       },
@@ -1360,9 +1360,9 @@
       "license": "MIT"
     },
     "node_modules/emp-wasm": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/emp-wasm/-/emp-wasm-0.2.2.tgz",
-      "integrity": "sha512-KcWLo1aEiAEFUOT1obFig77qvbkG+fuZ8tXIjyi5SdqkxsBg+nNFqKX2pGv0QStvkHcjtjt/VOwJKe92kT+TSA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/emp-wasm/-/emp-wasm-0.3.2.tgz",
+      "integrity": "sha512-iKWSUN9D89UBfa26c++zd2UnDyfdTf3UhVg4J/JXZ336MaREZCJXhi3DGFm9gEiQyrPAgYYGdDnR9y4bzr+hlg==",
       "license": "MIT",
       "dependencies": {
         "ee-typed": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emp-wasm-engine",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Engine for mpc-framework powered by emp-toolkit",
   "type": "module",
   "main": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@msgpack/msgpack": "^3.1.1",
     "@noble/hashes": "^1.7.1",
-    "emp-wasm": "^0.2.2",
+    "emp-wasm": "^0.3.2",
     "mpc-framework-common": "^0.3.0",
     "sort-keys": "^5.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "glob": "^11.0.1",
     "mpc-framework": "^0.3.0",
     "puppeteer-core": "^24.1.0",
-    "summon-ts": "^0.6.0",
+    "summon-ts": "^0.6.1",
     "tsx": "^4.9.3",
     "typescript": "^5.4.5",
     "vite": "^6.0.7"

--- a/src/EmpWasmEngine.ts
+++ b/src/EmpWasmEngine.ts
@@ -3,7 +3,6 @@ import {
   EngineSession,
   checkSettingsValid,
   Circuit,
-  MpcSettings,
 } from "mpc-framework-common";
 import EmpWasmSession from "./EmpWasmSession.js";
 import EmpCircuit from "./EmpCircuit.js";

--- a/src/EmpWasmSession.ts
+++ b/src/EmpWasmSession.ts
@@ -60,7 +60,7 @@ export default class EmpWasmSession implements EngineSession {
       if (partyName !== this.thisPartyName) {
         const setupHashReceived = await this.bqs
           .get(partyName, 'a')
-          .pop(setupHash.length);
+          .pop(setupHash.length, setupHash.length);
 
         if (!buffersEqual(setupHash, setupHashReceived)) {
           throw new Error(`Setup hash mismatch with ${partyName}`);
@@ -77,8 +77,8 @@ export default class EmpWasmSession implements EngineSession {
       io: {
         send: (toParty, channel, data) =>
           this.send(this.empCircuit.partyNameFromIndex(toParty), channel, data),
-        recv: (fromParty, channel, len) =>
-          this.bqs.get(this.empCircuit.partyNameFromIndex(fromParty), channel).pop(len),
+        recv: (fromParty, channel, min_len, max_len) =>
+          this.bqs.get(this.empCircuit.partyNameFromIndex(fromParty), channel).pop(min_len, max_len),
       },
     });
 

--- a/tests/helpers/suite.ts
+++ b/tests/helpers/suite.ts
@@ -56,12 +56,16 @@ export async function runSuite() {
       continue;
     }
 
+    const start = Date.now();
+
     try {
       await fn();
-      console.log(`✅ ${name}`);
+      const end = Date.now();
+      console.log(`✅ ${name} (${end - start}ms)`);
     } catch (e) {
+      const end = Date.now();
       failures++;
-      console.error(`❌ ${name}`);
+      console.error(`❌ ${name} (${end - start}ms)`);
 
       if (!puppeteerDetected) {
         console.error(e);

--- a/tests/mpc.test.ts
+++ b/tests/mpc.test.ts
@@ -173,6 +173,133 @@ test('boolean io', async () => {
   ]);
 });
 
+const getSha256Circuit = (() => {
+  let compileOutput: summon.CompileResult | undefined = undefined;
+
+  return async () => {
+    if (compileOutput) {
+      return compileOutput;
+    }
+
+    await summon.init();
+
+    const libVersion = 'c24b5f32ccb8d8ffe77fb1465425a0575012b4b7';
+    const ghPse = 'https://raw.githubusercontent.com/privacy-scaling-explorations';
+    const libBase = `${ghPse}/summon-lib/${libVersion}`;
+
+    async function downloadLib(path: string) {
+      const resp = await fetch(`${libBase}/${path}`);
+      const txt = await resp.text();
+
+      return txt;
+    }
+
+    compileOutput = summon.compile({
+      path: '/src/main.ts',
+      boolifyWidth: 8,
+      files: {
+        '/src/main.ts': `
+          import sha256 from './deps/sha256/mod.ts';
+
+          export default (io: Summon.IO) => {
+            // 6 characters * 8 bits, so we can encode 'summon'
+            const input = range(6 * 8).map(
+              i => io.input('alice', \`input\${i}\`, summon.bool()),
+            );
+
+            io.addParty('bob');
+
+            // expected: 2815cb02b95b6d15383bf551f09b33e01806ad2f4221b035a592c1be146d6a99
+            // (but encoded as bits)
+            const output = sha256(input);
+
+            for (const [i, b] of output.entries()) {
+              io.outputPublic(\`output\${i}\`, b);
+            }
+          };
+
+          export function range(limit: number) {
+            let res = [];
+
+            for (let i = 0; i < limit; i++) {
+              res.push(i);
+            }
+
+            return res;
+          }
+        `,
+        '/src/deps/sha256/mod.ts': await downloadLib('sha256/mod.ts'),
+        '/src/deps/sha256/sha256Compress.ts': await downloadLib('sha256/sha256Compress.ts'),
+      },
+    });
+
+    return compileOutput;
+  };
+})();
+
+test('compile sha256', async () => {
+  await getSha256Circuit();
+});
+
+test("sha256('summon') == 28..99", { skip: true }, async () => {
+  const { circuit } = await getSha256Circuit();
+
+  const protocol = new Protocol(circuit, new EmpWasmEngine());
+  const aqs = new AsyncQueueStore<Uint8Array>();
+
+  const summonBits = [...'summon']
+    .map(c => c.codePointAt(0)!.toString(2).padStart(8, '0'))
+    .join('').split('')
+    .map(bit => bit === '0' ? false : true);
+
+  const aliceInputs = Object.fromEntries(summonBits.entries().map(
+    ([i, boolBit]) => [`input${i}`, boolBit],
+  ));
+
+  const outputs = await Promise.all([
+    runParty(protocol, 'alice', aliceInputs, aqs),
+    runParty(protocol, 'bob', {}, aqs),
+  ]);
+
+  for (const output of outputs) {
+    const bits = range(256).map(i => output[`output${i}`] as boolean);
+    const outputHex = bitsToHex(bits);
+
+    expect(outputHex).to.eq('2815cb02b95b6d15383bf551f09b33e01806ad2f4221b035a592c1be146d6a99');
+  }
+});
+
+function range(limit: number) {
+  let res: number[] = [];
+
+  for (let i = 0; i < limit; i++) {
+    res.push(i);
+  }
+
+  return res;
+}
+
+function bitsToHex(bits: boolean[]) {
+  if (bits.length % 8 !== 0) {
+    throw new Error('bits do not form complete bytes');
+  }
+
+  let res = '';
+
+  for (let i = 0; i < bits.length; i += 8) {
+    let byte = 0;
+
+    for (let j = 0; j < 8; j++) {
+      const bit = Number(bits[i + j]);
+      byte |= bit << (7 - j);
+    }
+
+    res += byte.toString(16).padStart(2, '0');
+  }
+
+  return res;
+}
+
 async function runParty(
   protocol: Protocol,
   party: string,

--- a/tests/mpc.test.ts
+++ b/tests/mpc.test.ts
@@ -241,8 +241,14 @@ test('compile sha256', async () => {
   await getSha256Circuit();
 });
 
-test("sha256('summon') == 28..99", { skip: true }, async () => {
+test("sha256('summon') == 28..99", async () => {
+  const start = Date.now();
   const { circuit } = await getSha256Circuit();
+
+  // We rely (perhaps improperly) on `compile sha256` to have already been run
+  // so that the circuit is already cached. This way the test provides a measure
+  // of MPC performance, separate from summon compiling sha256.
+  expect(Date.now() - start).to.be.lessThan(50, 'Circuit should have been cached');
 
   const protocol = new Protocol(circuit, new EmpWasmEngine());
   const aqs = new AsyncQueueStore<Uint8Array>();


### PR DESCRIPTION
## What is this PR doing?

- Uses updated emp-wasm
- Uses updated summon-ts
- Adds sha256 tests
- Adds timing measurements to test output

## How can these changes be manually tested?

`npm test`

## Does this PR resolve or contribute to any issues?

Contributes to
- https://www.notion.so/pse-team/Investigate-huge-perf-gap-between-c-native-and-c-wasm-1a4d57e8dd7e80359976c2912f23aee3?source=copy_link
- https://www.notion.so/pse-team/sha256-20fd57e8dd7e80d183cafd5406324079?source=copy_link

## Checklist
- [x] I have manually tested these changes
- [ ] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
