### PR TITLE
Fix 32 bit ops

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "emp-wasm-engine",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "emp-wasm-engine",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emp-wasm-engine",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Engine for mpc-framework powered by emp-toolkit",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/EmpCircuit.ts
+++ b/src/EmpCircuit.ts
@@ -349,8 +349,10 @@ export default class EmpCircuit {
           `Expected input ${inputName} to be a number`,
         );
 
+        let v = BigInt(value);
         for (let i = 0; i < width; i++) {
-          bits.push((value >> i) & 1 ? true : false);
+          bits.push(v % 2n === 1n ? true : false);
+          v /= 2n;
         }
       } else if (type === 'bool') {
         assert(
@@ -379,7 +381,7 @@ export default class EmpCircuit {
       for (let i = 0; i < width; i++) {
         const address = this.addressMap.get(oldAddress + i);
         assert(address !== undefined, `Address ${oldAddress + i} not found`);
-        value |= outputBits[address - this.firstOutputAddress] << i;
+        value += outputBits[address - this.firstOutputAddress] * 2 ** i;
       }
 
       if (type === 'number') {

--- a/tests/mpc.test.ts
+++ b/tests/mpc.test.ts
@@ -87,7 +87,7 @@ test("middle(8, 17, 5) == 8", async () => {
 });
 
 // FIXME: use 5 bidders and auction house (which doesn't bid but observes)
-test("vickrey(8, 17, 5, 1, 70) == [4, 17]", { only: true }, async () => {
+test("vickrey(8, 17, 5, 1, 70) == [4, 17]", async () => {
   await summon.init();
 
   const { circuit } = summon.compile({


### PR DESCRIPTION
## What is this PR doing?

Fixes assumption that it's ok to do 32-bit arithmetic when encoding and decoding.

## How can these changes be manually tested?

`npm test`

## Does this PR resolve or contribute to any issues?

Nope.

## Checklist
- [x] I have manually tested these changes
- [ ] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
